### PR TITLE
Add fan-only climate mode support

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Turn your Olimpia Splendid HVAC into a smart climate system with ESPHome and Hom
 
 ## 🚀 Features
 
-- **Modbus ASCII communication** with Olimpia Splendid devices allowing full **climate control** 
+- **Modbus ASCII communication** with Olimpia Splendid devices allowing full **climate control** (heat, cool, fan-only, auto)
 - Communication behavior and timing comply with official Olimpia Splendid specifications & recommendations
 - **Smart temperature handling**:
   - **External temperature injection** from Home Assistant with RAM/EEPROM fallback

--- a/components/olimpia_bridge/olimpia_bridge_climate.h
+++ b/components/olimpia_bridge/olimpia_bridge_climate.h
@@ -23,6 +23,7 @@ enum class Mode : uint8_t {
   AUTO     = 0b00,
   HEATING  = 0b01,
   COOLING  = 0b10,
+  FAN_ONLY = 0b11,
 };
 
 // --- Fan speed levels (PRG bits 0–2) ---
@@ -72,6 +73,7 @@ inline ParsedState parse_command_register(uint16_t reg) {
     case 0b00: st.mode = Mode::AUTO; break;
     case 0b01: st.mode = Mode::HEATING; break;
     case 0b10: st.mode = Mode::COOLING; break;
+    case 0b11: st.mode = Mode::FAN_ONLY; break;
     default:   st.mode = Mode::AUTO; break;
   }
 


### PR DESCRIPTION
## Summary
- add fan-only to the OlimpiaBridge climate mode parsing/building and action handling
- expose the new fan-only climate mode to Home Assistant traits and document full mode coverage

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e4fe5e01188323b91e7b670c363697