### PR TITLE
Add fan-only climate mode support

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Turn your Olimpia Splendid HVAC into a smart climate system with ESPHome and Hom
 
 ## 🚀 Features
 
-- **Modbus ASCII communication** with Olimpia Splendid devices allowing full **climate control** 
+- **Modbus ASCII communication** with Olimpia Splendid devices allowing full **climate control** (heat, cool, fan-only, auto)
 - Communication behavior and timing comply with official Olimpia Splendid specifications & recommendations
 - **Smart temperature handling**:
   - **External temperature injection** from Home Assistant with RAM/EEPROM fallback

--- a/components/olimpia_bridge/olimpia_bridge_climate.cpp
+++ b/components/olimpia_bridge/olimpia_bridge_climate.cpp
@@ -24,6 +24,7 @@ static constexpr ModeInfo MODE_INFO[] = {
     {Mode::AUTO, "AUTO", climate::CLIMATE_MODE_AUTO},
     {Mode::HEATING, "HEAT", climate::CLIMATE_MODE_HEAT},
     {Mode::COOLING, "COOL", climate::CLIMATE_MODE_COOL},
+    {Mode::FAN_ONLY, "FAN", climate::CLIMATE_MODE_FAN_ONLY},
 };
 
 static constexpr FanSpeedInfo FAN_SPEED_INFO[] = {
@@ -124,6 +125,9 @@ uint16_t OlimpiaBridgeClimate::build_command_register(bool on, Mode mode, FanSpe
     case Mode::COOLING:
       reg |= (0b10 << 13);
       break;
+    case Mode::FAN_ONLY:
+      reg |= (0b11 << 13);
+      break;
     default:
       reg |= (0b00 << 13);  // Fallback to AUTO
       break;
@@ -174,7 +178,8 @@ climate::ClimateTraits OlimpiaBridgeClimate::traits() {
   std::set<climate::ClimateMode> supported_modes = {
     climate::CLIMATE_MODE_OFF,
     climate::CLIMATE_MODE_COOL,
-    climate::CLIMATE_MODE_HEAT
+    climate::CLIMATE_MODE_HEAT,
+    climate::CLIMATE_MODE_FAN_ONLY
   };
   if (!this->disable_mode_auto_) {
     supported_modes.insert(climate::CLIMATE_MODE_AUTO);
@@ -240,6 +245,10 @@ void OlimpiaBridgeClimate::control(const climate::ClimateCall &call) {
       case climate::CLIMATE_MODE_HEAT:
         this->on_ = true;
         this->mode_ = Mode::HEATING;
+        break;
+      case climate::CLIMATE_MODE_FAN_ONLY:
+        this->on_ = true;
+        this->mode_ = Mode::FAN_ONLY;
         break;
       case climate::CLIMATE_MODE_AUTO:
         this->on_ = true;
@@ -543,7 +552,7 @@ void OlimpiaBridgeClimate::restore_or_refresh_state() {
       ParsedState parsed = parse_command_register(reg101);
 
       ESP_LOGD(TAG, "[%s] Read 101: 0x%04X → ON=%d MODE=%d FAN=%d", this->get_name().c_str(),
-               reg101, parsed.on, parsed.mode, static_cast<int>(parsed.fan_speed));
+               reg101, parsed.on, static_cast<int>(parsed.mode), static_cast<int>(parsed.fan_speed));
 
       this->handler_->read_register(this->address_, 102, 1,
         [this, parsed, is_boot_cycle](bool ok102, const std::vector<uint16_t> &data102) {
@@ -622,6 +631,8 @@ void OlimpiaBridgeClimate::update_climate_action_from_valve_status() {
           new_action = climate::CLIMATE_ACTION_COOLING;
         } else if (this->mode_ == Mode::HEATING) {
           new_action = climate::CLIMATE_ACTION_HEATING;
+        } else if (this->mode_ == Mode::FAN_ONLY) {
+          new_action = climate::CLIMATE_ACTION_FAN;
         } else if (this->mode_ == Mode::AUTO) {
           // AUTO requires additional inference
           if (boiler && !chiller)

--- a/components/olimpia_bridge/olimpia_bridge_climate.h
+++ b/components/olimpia_bridge/olimpia_bridge_climate.h
@@ -23,6 +23,7 @@ enum class Mode : uint8_t {
   AUTO     = 0b00,
   HEATING  = 0b01,
   COOLING  = 0b10,
+  FAN_ONLY = 0b11,
 };
 
 // --- Fan speed levels (PRG bits 0–2) ---
@@ -72,6 +73,7 @@ inline ParsedState parse_command_register(uint16_t reg) {
     case 0b00: st.mode = Mode::AUTO; break;
     case 0b01: st.mode = Mode::HEATING; break;
     case 0b10: st.mode = Mode::COOLING; break;
+    case 0b11: st.mode = Mode::FAN_ONLY; break;
     default:   st.mode = Mode::AUTO; break;
   }
 


### PR DESCRIPTION
## Summary
- add fan-only to the OlimpiaBridge climate mode parsing/building and action handling
- expose the new fan-only climate mode to Home Assistant traits and document full mode coverage

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e4fe5e01188323b91e7b670c363697